### PR TITLE
:compiled templates/snippets creation before the DOM is loaded

### DIFF
--- a/project/cljs-src/enfocus/core.cljs
+++ b/project/cljs-src/enfocus/core.cljs
@@ -135,7 +135,7 @@
         (log-debug (count (domina/nodes child))) 
         (doseq [node (domina/nodes child)]
           (dom/appendChild div node))))
-    (dom/appendChild (.-body (dom/getDocument)) div)
+    (dom/appendChild (.-documentElement (dom/getDocument)) div)
     div))   
     
 (defn remove-node-return-child 


### PR DESCRIPTION
When under creation, templates or snippets are added to the root DOM
element instead of the body DOM element.
