### PR TITLE
Incompatibility with clojurescript 0.0-1586

### DIFF
--- a/project/cljs-src/enfocus/core.cljs
+++ b/project/cljs-src/enfocus/core.cljs
@@ -7,7 +7,6 @@
             [goog.dom :as dom]
             [goog.dom.classes :as classes]
             [goog.dom.ViewportSizeMonitor :as vsmonitor]
-            [goog.events :as events]
             [goog.fx :as fx]
             [goog.fx.dom :as fx-dom]
             [goog.async.Delay :as gdelay]


### PR DESCRIPTION
Removed duplicate :require directive that made enfocus incompatible with clojurescript 0.0-1586
