### PR TITLE
added 'set-data' transformation function

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -236,6 +236,7 @@ New Transformations
                             (move x y ttime)
                             (fade-out ttime)
                             ...)
+  set-data           (set-data :name value)
 </pre>
 
 Currently there is one transformation that is supported by Enlive but not Enfocus. (Patches very welcome!!)

--- a/project/cljs-src/enfocus/core.cljs
+++ b/project/cljs-src/enfocus/core.cljs
@@ -254,6 +254,13 @@
   [txt]
   (multi-node-chain #(domina/set-html! % txt)))
 
+(defn set-data
+  "Sets a data sttribute on the selected element."
+  [data-name data-value]
+  (fn [node]
+    (aset (.-dataset (domina/single-node node))
+          (name data-name)
+          data-value)))
 
 (defn set-attr
   "Assocs attributes and values on the selected element."

--- a/project/cljs-src/enfocus/testing.cljs
+++ b/project/cljs-src/enfocus/testing.cljs
@@ -5,6 +5,9 @@
             [enfocus.events :as events])
   (:require-macros [enfocus.macros :as em]))
 
+(defn test-data []
+  (ef/at js/document
+         ["body"] (ef/set-data :foo "bar")))
 
 (defn test-from []
   (let [form-vals (ef/from js/document


### PR DESCRIPTION
this allows attaching data to nodes during transformations, which can then be used later.  so for example...

``` clojure
[:li] (clone-for [item items]
        [:.select] (set-data :item item)
        [:.title] (content (:title item))
```

(in my case i then attach click handlers separately, which will use the item data)

not sure if this is something you want to include in the library, if there's a better way of handling this that i'm missing then i'd love to just know that instead :)
