### PR TITLE
Fixes compiling WARNING: Use of undeclared Var enfocus.core/Utility

### DIFF
--- a/project/cljs-src/enfocus/core.cljs
+++ b/project/cljs-src/enfocus/core.cljs
@@ -1,4 +1,3 @@
-
 (ns enfocus.core
   (:refer-clojure :exclude [filter delay])
   (:require [enfocus.enlive.syntax :as en]
@@ -31,9 +30,7 @@
     "takes a set of nodes and performs a transform on them"))
 
 ;#################################################### 
-
-                                        ;
-Utility functions
+; Utility functions
 ;####################################################
 (def debug true)
 


### PR DESCRIPTION
and WARNING: Use of undeclared Var enfocus.core/functions
by removing a new line that was in a wrong place
