### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target
 .metadata
 .project
 .classpath
+resources/*.js
 *.*#
 .#*
 *.*~


### PR DESCRIPTION
I added the `resources/*js` rule to allow the `runners/phantomjs.js` to be included in the repo without including the emitted JS file too.
