### PR TITLE
See #70: Execute handler on original event in listen-live.

### DIFF
--- a/project/cljs-src/enfocus/events.cljs
+++ b/project/cljs-src/enfocus/events.cljs
@@ -93,12 +93,17 @@
 (defn listen-live [event selector func]
   (fn [node]
     (ef/at node
-           (listen event
-                   #(doseq [el (get-node-chain node (.-target %))]
-                      (ef/at el
-                             (ef/filter (ef/match? selector)
-                                        (fn [node]
-                                          (func (create-event event el (.-target %)))))))))))
+     (listen event
+       #(doseq [el (get-node-chain node (.-target %))]
+          (ef/at el
+           (ef/filter (ef/match? selector)
+                      (fn [node]
+                        (let [event-copy (create-event event el (.-target %))]
+                          (func event-copy)
+                          (when (.-defaultPrevented event-copy)
+                            (.preventDefault %))
+                          (when (.-propagationStopped event-copy)
+                            (.stopPropagation %)))))))))))
 
 
 ;###################################################


### PR DESCRIPTION
As stated in #70, Currently, the original event is discarded, and the event handler is run on a new `goog.events.Event` with the same target property. This makes `.preventDefault` and `.stopPropagation` impossible.

With this commit, `listen-live` will execute the handler on the original event object, and then return a new event. This strikes a compromise between immutability and the need to cause side effects.
