### PR TITLE
Delete ring.clj

### DIFF
--- a/src/clj/enfocus/ring.clj
+++ b/src/clj/enfocus/ring.clj
@@ -1,8 +1,0 @@
-(ns enfocus.ring
-  (:use ring.middleware.file
-        ring.handler.dump))
-
- (def app
-  (wrap-file handle-dump "resources/public"))
- 
- 


### PR DESCRIPTION
It is not used anymore. It was there only as a placeholder at the beginning of the directories layout refactoring.
