### PR TITLE
add last-element-child fn in enfocus.core to call from macros to avoid warning

### DIFF
--- a/src/clj/enfocus/macros.clj
+++ b/src/clj/enfocus/macros.clj
@@ -123,7 +123,7 @@
        (doseq [~sym ~lst]
          (do 
            (enfocus.core/at div#  (enfocus.core/append (. pnod# (~(symbol "cloneNode") true))))
-           (enfocus.core/at (goog.dom/getLastElementChild div#) ~@forms)))
+           (enfocus.core/at (enfocus.core/last-element-child div#) ~@forms)))
        (enfocus.core/log-debug div#)
        (enfocus.core/at 
         pnod# 

--- a/src/cljs/enfocus/core.cljs
+++ b/src/cljs/enfocus/core.cljs
@@ -98,7 +98,7 @@
 
 ;####################################################
 ; The following functions are used to manage the
-; emote dom features for templates and snippets
+; remote dom features for templates and snippets
 ;####################################################
 
 (def tpl-load-cnt
@@ -135,6 +135,10 @@
     (dom/append frag child)
     (dom/removeNode div)
     frag))
+
+(defn last-element-child [node]
+  "last child node that is an element"
+  (dom/getLastElementChild node))
 
 
 (defn replace-ids


### PR DESCRIPTION
we have a number of

`WARNING: No such namespace: goog.dom at line ...`

messages building our projects. Fixed by adding a resolvable reference to enfocus.core rather than goog.dom
