### PR TITLE
Fixed get-text: doesn't eat newlines anymore. Removed unnecessary import.

### DIFF
--- a/src/cljs/enfocus/core.cljs
+++ b/src/cljs/enfocus/core.cljs
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [filter delay])
   (:require [enfocus.enlive.syntax :as en]
             [goog.net.XhrIo :as xhr]
-            [goog.dom.query :as query]
             [goog.style :as style]
             [goog.events :as events]
             [goog.dom :as dom]
@@ -544,7 +543,7 @@
   []
   (extr-multi-node
     (fn[pnod]
-      (dom/getTextContent pnod))))
+      (.-textContent pnod))))
 
 (defn get-data
   "returns the data on a selected node for a given key. If bubble is set will look at parent"


### PR DESCRIPTION
`get-text` using Google Closure kills newlines. With newline-sensitive text and markup like Textile, this is a problem. Using `.-textContent` instead fixes this problem.